### PR TITLE
Some fix for subtitles

### DIFF
--- a/VideoDownloader.App/BL/PluralsightCourseService.cs
+++ b/VideoDownloader.App/BL/PluralsightCourseService.cs
@@ -197,7 +197,7 @@ namespace VideoDownloader.App.BL
         private List<SrtRecord> GetFormattedSubtitles(Caption[] captions, int totalDuration)
         {
             List<SrtRecord> srtRecords = new List<SrtRecord>();
-            CultureInfo culture = new CultureInfo("us");
+            System.Globalization.CultureInfo culture = new System.Globalization.CultureInfo("us");
 
             for (int i = 0; i < captions.Count() - 1; ++i)
             {

--- a/VideoDownloader.App/BL/PluralsightCourseService.cs
+++ b/VideoDownloader.App/BL/PluralsightCourseService.cs
@@ -197,13 +197,14 @@ namespace VideoDownloader.App.BL
         private List<SrtRecord> GetFormattedSubtitles(Caption[] captions, int totalDuration)
         {
             List<SrtRecord> srtRecords = new List<SrtRecord>();
+            CultureInfo culture = new CultureInfo("us");
 
             for (int i = 0; i < captions.Count() - 1; ++i)
             {
                 SrtRecord srtRecord = new SrtRecord
                 {
-                    FromTimeSpan = TimeSpan.FromSeconds(double.Parse(captions[i].DisplayTimeOffset)),
-                    ToTimeSpan = TimeSpan.FromSeconds(double.Parse(captions[i + 1].DisplayTimeOffset) - 0.1),
+                    FromTimeSpan = TimeSpan.FromSeconds(double.Parse(captions[i].DisplayTimeOffset, culture)),
+                    ToTimeSpan = TimeSpan.FromSeconds(double.Parse(captions[i + 1].DisplayTimeOffset, culture) - 0.1),
                     Text = (captions[i].Text)
                 };
                 srtRecords.Add(srtRecord);
@@ -211,7 +212,7 @@ namespace VideoDownloader.App.BL
 
             SrtRecord finalSrtRecord = new SrtRecord
             {
-                FromTimeSpan = TimeSpan.FromSeconds(Double.Parse(captions.Last().DisplayTimeOffset)),
+                FromTimeSpan = TimeSpan.FromSeconds(Double.Parse(captions.Last().DisplayTimeOffset, culture)),
                 ToTimeSpan = TimeSpan.FromSeconds(Convert.ToDouble(totalDuration) - 0.1),
                 Text = captions.Last().Text
             };

--- a/VideoDownloader.App/BL/PluralsightCourseService.cs
+++ b/VideoDownloader.App/BL/PluralsightCourseService.cs
@@ -204,7 +204,7 @@ namespace VideoDownloader.App.BL
                 SrtRecord srtRecord = new SrtRecord
                 {
                     FromTimeSpan = TimeSpan.FromSeconds(double.Parse(captions[i].DisplayTimeOffset, culture)),
-                    ToTimeSpan = TimeSpan.FromSeconds(double.Parse(captions[i + 1].DisplayTimeOffset, culture) - 0.1),
+                    ToTimeSpan = TimeSpan.FromSeconds(double.Parse(captions[i + 1].DisplayTimeOffset, culture)),
                     Text = (captions[i].Text)
                 };
                 srtRecords.Add(srtRecord);
@@ -213,7 +213,7 @@ namespace VideoDownloader.App.BL
             SrtRecord finalSrtRecord = new SrtRecord
             {
                 FromTimeSpan = TimeSpan.FromSeconds(Double.Parse(captions.Last().DisplayTimeOffset, culture)),
-                ToTimeSpan = TimeSpan.FromSeconds(Convert.ToDouble(totalDuration) - 0.1),
+                ToTimeSpan = TimeSpan.FromSeconds(Convert.ToDouble(totalDuration)),
                 Text = captions.Last().Text
             };
 

--- a/VideoDownloader.App/BL/SubtitleService.cs
+++ b/VideoDownloader.App/BL/SubtitleService.cs
@@ -19,7 +19,7 @@ namespace VideoDownloader.App.BL
                 foreach (var record in subtitleRecords)
                 {
                     sw.WriteLine(index);
-                    sw.WriteLine($"{record.FromTimeSpan:hh\\:mm\\:ss\\.FFF} --> {record.ToTimeSpan:hh\\:mm\\:ss\\.FFF}");
+                    sw.WriteLine($"{record.FromTimeSpan.ToString("hh':'mm':'ss':'fff")} --> {record.ToTimeSpan.ToString("hh':'mm':'ss':'fff")}");
                     sw.WriteLine(record.Text);
                     sw.WriteLine();
                     ++index;


### PR DESCRIPTION
Для парсинга строки в double в windows с другими локализациями, например в русской, требует в числе double знак "," вместо "."
Пофиксил тайминги субтитров и их формат вывода.